### PR TITLE
feat: enable notification sound

### DIFF
--- a/src-tauri/src/utils/notifications.rs
+++ b/src-tauri/src/utils/notifications.rs
@@ -1,10 +1,11 @@
-use tauri::api::notification::Notification;
+use tauri::api::notification::{Notification, Sound};
 
 pub fn warn(message: &str) {
     let ctx = tauri::generate_context!();
     let notification = Notification::new(&ctx.config().tauri.bundle.identifier)
         .title("Warning")
         .body(message)
+        .sound(Sound::Default)
         .show();
     match notification {
         Ok(_) => println!("[RUST]: Notification shown successfully"),


### PR DESCRIPTION
The notification is not intrusive but making it cause a sound provides better way to alert the user.